### PR TITLE
Better extensibility of Query class

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -14,10 +14,10 @@ use yii\web\HttpException;
 use yii\web\ServerErrorHttpException;
 
 /**
- * Class Query 
+ * Class Query
  * HTTP transport by GuzzleHTTP
- * 
- * @package chsergey\rest 
+ *
+ * @package chsergey\rest
  */
 class Query extends Component implements QueryInterface {
 	/**
@@ -84,13 +84,13 @@ class Query extends Component implements QueryInterface {
 	 * @see chsergey\rest\Model::$collectionEnvelope
 	 * @var string
 	 */
-	private $_collectionEnvelope;
+	protected $_collectionEnvelope;
 	/**
 	 * Model class pagination envelope
 	 * @see chsergey\rest\Model::$paginationEnvelope
 	 * @var string
 	 */
-	private $_paginationEnvelope;
+	protected $_paginationEnvelope;
 	/**
 	 * Model class pagination envelope keys mapping
 	 * @see chsergey\rest\Model::$paginationEnvelopeKeys
@@ -328,7 +328,7 @@ class Query extends Component implements QueryInterface {
 	 * @return $this|Model|array|void
 	 * @throws HttpException
 	 */
-	private function _populate(ResponseInterface $response, $asCollection = true) {
+	protected function _populate(ResponseInterface $response, $asCollection = true) {
 		$models = [];
 		$statusCode = $response->getStatusCode();
 		$data = $this->_unserializeResponseBody($response);
@@ -376,7 +376,7 @@ class Query extends Component implements QueryInterface {
 	 * @param array $elements
 	 * @return array
 	 */
-	private function _createModels(array $elements) {
+	protected function _createModels(array $elements) {
 		$modelClass = $this->modelClass;
 		$models = [];
 		foreach ($elements as $element) {
@@ -395,7 +395,7 @@ class Query extends Component implements QueryInterface {
 	 * @return object[]|object|string
 	 * @throws \yii\base\InvalidConfigException
 	 */
-	private function _unserializeResponseBody(ResponseInterface $response) {
+	protected function _unserializeResponseBody(ResponseInterface $response) {
 
 		$body = (string) $response->getBody();
 		$contentType = $response->getHeaderLine('Content-type');

--- a/src/Query.php
+++ b/src/Query.php
@@ -58,6 +58,11 @@ class Query extends Component implements QueryInterface {
 	 */
 	public $httpClient;
 	/**
+	 * Configuration to be supplied to the HTTP client
+	 * @var array
+	 */
+	public $httpClientExtraConfig = [];
+	/**
 	 * Model class
 	 * @var Model
 	 */
@@ -146,12 +151,16 @@ class Query extends Component implements QueryInterface {
 		$this->offsetKey = $modelClass::$offsetKey;
 		$this->limitKey = $modelClass::$limitKey;
 
-		$this->httpClient = new Client([
-			/* @link http://docs.guzzlephp.org/en/latest/quickstart.html */
-			'base_uri' => $this->_getUrl('api'),
-			/* @link http://docs.guzzlephp.org/en/latest/request-options.html#headers */
-			'headers' => $this->_getRequestHeaders(),
-		]);
+		$httpClientConfig = array_merge(
+			[
+				/* @link http://docs.guzzlephp.org/en/latest/quickstart.html */
+				'base_uri' => $this->_getUrl('api'),
+				/* @link http://docs.guzzlephp.org/en/latest/request-options.html#headers */
+				'headers' => $this->_getRequestHeaders(),
+			],
+			$this->httpClientExtraConfig
+		);
+		$this->httpClient = new Client($httpClientConfig);
 
 		parent::__construct($config);
 	}


### PR DESCRIPTION
Problem: In my project I needed to customize the way how exceptions are thrown in _populate() method, so I created a child class and overrode _populate method there. Since the response processing logic is encapsulated into several private methods, I had to pull most of them into my class in order to have everything working.

This PR introduces 2 changes:
- visibility of some methods changed to protected, so that it's not necessary to override all dependent methods of _populate
- added httpClientExtraConfig property so that subclass can extend/override configuration of the http client.